### PR TITLE
#156577922 Set timeouts and grace values for days exceeding 30

### DIFF
--- a/hc/api/schemas.py
+++ b/hc/api/schemas.py
@@ -2,8 +2,8 @@ check = {
     "properties": {
         "name": {"type": "string"},
         "tags": {"type": "string"},
-        "timeout": {"type": "number", "minimum": 60, "maximum": 604800},
-        "grace": {"type": "number", "minimum": 60, "maximum": 604800},
+        "timeout": {"type": "number", "minimum": 60, "maximum": 31104000},
+        "grace": {"type": "number", "minimum": 60, "maximum": 31104000},
         "channels": {"type": "string"}
     }
 }

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -116,7 +116,7 @@ class CreateCheckTestCase(BaseTestCase):
             "api_key": "abc",
             "name": "Foo",
             "tags": "bar,baz",
-            "timeout": 604801,
+            "timeout": 31104001,
             "grace": 60
         })
         

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -18,8 +18,8 @@ class NameTagsForm(forms.Form):
 
 
 class TimeoutForm(forms.Form):
-    timeout = forms.IntegerField(min_value=60, max_value=2592000)
-    grace = forms.IntegerField(min_value=60, max_value=2592000)
+    timeout = forms.IntegerField(min_value=60, max_value=31104000)
+    grace = forms.IntegerField(min_value=60, max_value=31104000)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/hc/front/templatetags/hc_extras.py
+++ b/hc/front/templatetags/hc_extras.py
@@ -13,6 +13,8 @@ MINUTE = Unit("minute", 60)
 HOUR = Unit("hour", MINUTE.nsecs * 60)
 DAY = Unit("day", HOUR.nsecs * 24)
 WEEK = Unit("week", DAY.nsecs * 7)
+MONTH = Unit("month", DAY.nsecs * 30)
+YEAR = Unit("year", MONTH.nsecs * 12)
 
 
 @register.filter
@@ -20,8 +22,8 @@ def hc_duration(td):
     remaining_seconds = int(td.total_seconds())
     result = []
 
-    for unit in (WEEK, DAY, HOUR, MINUTE):
-        if unit == WEEK and remaining_seconds % unit.nsecs != 0:
+    for unit in (YEAR, MONTH, WEEK, DAY, HOUR, MINUTE):
+        if unit == MONTH and remaining_seconds % unit.nsecs != 0:
             # Say "8 days" instead of "1 week 1 day"
             continue
 

--- a/hc/front/tests/test_hc_extras.py
+++ b/hc/front/tests/test_hc_extras.py
@@ -14,8 +14,11 @@ class HcExtrasTestCase(TestCase):
             (86400, "1 day"),
             (604800, "1 week"),
             (2419200, "4 weeks"),
-            (2592000, "30 days"),
-            (3801600, "44 days")
+            (2592000, "1 month"),
+            (5184000, "2 months"),
+            (15552000, "6 months"),
+            (31104000, "1 year")
+
         ]
 
         for seconds, expected_result in samples:

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -4,13 +4,15 @@ $(function () {
     var HOUR = {name: "hour", nsecs: MINUTE.nsecs * 60};
     var DAY = {name: "day", nsecs: HOUR.nsecs * 24};
     var WEEK = {name: "week", nsecs: DAY.nsecs * 7};
-    var UNITS = [WEEK, DAY, HOUR, MINUTE];
+    var MONTH = {name: "month", nsecs: DAY.nsecs * 30};
+    var YEAR = {name: "year", nsecs: MONTH.nsecs * 12};
+    var UNITS = [YEAR, MONTH, WEEK, DAY, HOUR, MINUTE];
 
     var secsToText = function(total) {
         var remainingSeconds = Math.floor(total);
         var result = "";
         for (var i=0, unit; unit=UNITS[i]; i++) {
-            if (unit === WEEK && remainingSeconds % unit.nsecs != 0) {
+            if (unit === MONTH && remainingSeconds % unit.nsecs != 0) {
                 // Say "8 days" instead of "1 week 1 day"
                 continue
             }
@@ -35,15 +37,16 @@ $(function () {
         start: [20],
         connect: "lower",
         range: {
-            'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            'min':  60,
+            '24%': [3600, 3600],
+            '48%': [86400, 86400],
+            '60%': [604800, 604800],
+            '73%': [2592000, 2592000],
+            'max': 31104000
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000, 15552000, 31104000],
             density: 4,
             format: {
                 to: secsToText,
@@ -64,15 +67,16 @@ $(function () {
         start: [20],
         connect: "lower",
         range: {
-            'min': [60, 60],
-            '33%': [3600, 3600],
-            '66%': [86400, 86400],
-            '83%': [604800, 604800],
-            'max': 2592000,
+            'min':  60,
+            '24%': [3600, 3600],
+            '48%': [86400, 86400],
+            '60%': [604800, 604800],
+            '73%': [2592000, 2592000],
+            'max': 31104000
         },
         pips: {
             mode: 'values',
-            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000],
+            values: [60, 1800, 3600, 43200, 86400, 604800, 2592000, 15552000, 31104000],
             density: 4,
             format: {
                 to: secsToText,


### PR DESCRIPTION
## What does this PR do?
This PR allows the user to set timeouts and grace values for days exceeding 30

## Description of task completed?
- The slider can now move from 1 month to 1 year allowing monthly grace and timeout periods.
![snippet](https://user-images.githubusercontent.com/26734746/39477723-c94661da-4d68-11e8-9008-7d806c29917c.PNG)

## Any background context you want to provide?
The feature added was not available initially. A user could only set timeout and grace period for a maximum of one month. This PR enables monthly scheduling.

## How can this be manually tested
Run the application and create a check. Click on the timeout and grace period of the new check. It should have the maximum time as one year. 

## What are the relevant pivotal tracker stories?
[Feature #156577922](https://www.pivotaltracker.com/story/show/156577922)