### PR TITLE
#156577920 Create a dashboard for failed checks

### DIFF
--- a/hc/front/tests/test_my_failed_checks.py
+++ b/hc/front/tests/test_my_failed_checks.py
@@ -1,0 +1,56 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+from datetime import timedelta as td
+from django.utils import timezone
+from hc.front.views import my_failed_checks
+
+
+class MyFailedChecksTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(MyFailedChecksTestCase, self).setUp()
+        self.check = Check(user=self.alice, name="Alice Was Here")
+        self.check.save()
+
+    def test_failed_checks_url_works(self):
+        """Tests whether the failed_checks url works"""
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/failed_checks/")
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_only_failed_checks_are_returned(self):
+        """Tests whether only checks with status down are returned"""
+
+        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.status = "down"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/failed_checks/")
+        self.assertContains(response, "Alice Was Here")
+
+    def test_up_checks_not_returned(self):
+        """Tests whether checks with status up are not returned"""
+        
+        self.check.last_ping = timezone.now()
+        self.check.status = "up"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/failed_checks/")
+        self.assertNotIn( "Alice Was Here", response)
+
+    def test_grace_checks_not_returned(self):
+        """Tests whether checks with status grace are not returned"""
+
+        self.check.last_ping = timezone.now() - td(days=1, minutes=30)
+        self.check.status = "up"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        response = self.client.get("/failed_checks/")
+        self.assertNotIn( "Alice Was Here", response)
+
+

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -31,10 +31,10 @@ channel_urls = [
 urlpatterns = [
     url(r'^$', views.index, name="hc-index"),
     url(r'^checks/$', views.my_checks, name="hc-checks"),
+    url(r'^failed_checks/$', views.my_failed_checks, name="hc-failed-checks"),
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
-
     url(r'^docs/$', views.docs, name="hc-docs"),
     url(r'^docs/api/$', views.docs_api, name="hc-docs-api"),
     url(r'^about/$', views.about, name="hc-about"),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -50,10 +50,28 @@ def my_checks(request):
     ctx = {
         "page": "checks",
         "checks": checks,
+        "page_title": "My Checks",
         "now": timezone.now(),
         "tags": counter.most_common(),
         "down_tags": down_tags,
         "grace_tags": grace_tags,
+        "ping_endpoint": settings.PING_ENDPOINT
+    }
+
+    return render(request, "front/my_checks.html", ctx)
+
+@login_required
+def my_failed_checks(request):
+    """Function to get all failed checks"""
+
+    checks = list(Check.objects.filter(user=request.team.user).order_by("created"))
+    failed_checks = [check for check in checks if check.get_status() == "down"]
+
+    ctx = {
+        "page": "failed_checks",
+        "checks": failed_checks,
+        "page_title": 'My Failed Checks',
+        "now": timezone.now(),
         "ping_endpoint": settings.PING_ENDPOINT
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,10 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'failed_checks' %} class="active" {% endif %}>
+                        <a href="{% url 'hc-failed-checks' %}">Failed Checks</a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load compress staticfiles %}
 
-{% block title %}My Checks - healthchecks.io{% endblock %}
+{% block title %}{{page_title}} - healthchecks.io{% endblock %}
 
 
 {% block content %}
@@ -9,7 +9,7 @@
     <div class="col-sm-12">
         <h1>
         {% if request.team == request.user.profile %}
-            My Checks
+            {{page_title}}
         {% else %}
             {{ request.team.team_name }}
         {% endif %}


### PR DESCRIPTION
### What does this PR do?
This PR creates a dashboard for all failed checks for a particular user.
#### Description of Task to be completed?
Created a dashboard where a user after getting an email notification about their failed checks, can log into healthchecks and view the failed checks on a separate dashboard.
![untitled](https://user-images.githubusercontent.com/35847046/39514357-9ebaf29a-4dff-11e8-9f0f-bbc726a81d75.jpg)

#### How should this be manually tested?
Run the application, after login, create some checks and have some of those checks fail. Then navigate to failed checks using the link provided in the navigation menu
#### Any background context you want to provide?
Previously, there was no UI where a user could view only the failed checks.
#### What are the relevant pivotal tracker stories?
[#156577920](https://www.pivotaltracker.com/story/show/156577920)