### PR TITLE
#156577923 Send Email alert when a job is run too often

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -17,7 +17,8 @@ STATUSES = (
     ("up", "Up"),
     ("down", "Down"),
     ("new", "New"),
-    ("paused", "Paused")
+    ("paused", "Paused"),
+    ("often", "Often")
 )
 DEFAULT_TIMEOUT = td(days=1)
 DEFAULT_GRACE = td(hours=1)
@@ -69,7 +70,7 @@ class Check(models.Model):
         return "%s@%s" % (self.code, settings.PING_EMAIL_DOMAIN)
 
     def send_alert(self):
-        if self.status not in ("up", "down"):
+        if self.status not in ("up", "down", "often"):
             raise NotImplementedError("Unexpected status: %s" % self.status)
 
         errors = []
@@ -87,6 +88,8 @@ class Check(models.Model):
         now = timezone.now()
 
         if self.last_ping + self.timeout + self.grace > now:
+            if self.status =="often":
+                return "often"
             return "up"
 
         return "down"

--- a/hc/api/tests/test_ping.py
+++ b/hc/api/tests/test_ping.py
@@ -103,3 +103,11 @@ class PingTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(self.check.status, "up")
 
+    def test_it_handles_check_running_often(self):
+        r = self.client.get("/ping/%s/" % self.check.code)
+        assert r.status_code == 200
+        
+        r = self.client.get("/ping/%s/" % self.check.code)
+        assert r.status_code == 200
+        self.check.refresh_from_db()
+        assert self.check.status == "often"

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -20,6 +20,17 @@ def ping(request, code):
         check = Check.objects.get(code=code)
     except Check.DoesNotExist:
         return HttpResponseBadRequest()
+    
+    last_ping_time = check.last_ping
+    current_ping_time = timezone.now()
+
+    if last_ping_time is not None and \
+        current_ping_time < ((last_ping_time + check.timeout) - check.grace):
+        check.send_alert()
+        check.status = "often"
+    else:
+        check.status = "up"
+
 
     check.n_pings = F("n_pings") + 1
     check.last_ping = timezone.now()

--- a/hc/front/tests/test_my_checks.py
+++ b/hc/front/tests/test_my_checks.py
@@ -58,3 +58,12 @@ class MyChecksTestCase(BaseTestCase):
 
         # Mobile
         self.assertContains(r, "label-warning")
+    
+    def test_it_shows_red_check(self):
+        self.check.last_ping = timezone.now() - td(hours=23)
+        self.check.status = "often"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.get("/checks/")
+        self.assertContains(r, "status icon-up often")

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -58,6 +58,7 @@ body {
 }
 
 .status.icon-up { color: #5cb85c; }
+.status.icon-up.often { color: #d9534f; }
 .status.icon-up.new, .status.icon-paused { color: #CCC; }
 .status.icon-grace { color: #f0ad4e; }
 .status.icon-down { color: #d9534f; }

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -24,6 +24,9 @@
                 <span class="status icon-grace"></span>
             {% elif check.get_status == "up" %}
                 <span class="status icon-up"></span>
+            {% elif check.get_status == "often" %}
+                <span class="status icon-up often" 
+                    data-toggle="tooltip" title="This job is being run too often."></span>
             {% elif check.get_status == "down" %}
                 <span class="status icon-down"></span>
             {% endif %}


### PR DESCRIPTION
**What does this PR do?**
This PR enables an Email alert to be sent to a user when a job is run too often and creates an icon on the dashboard for alerts that are run too often

**Description of Task to be completed?**
When a job is pinged too early, an Email alert is sent to the user and the status icon of the job changes to red.

**How should this be manually tested?**
1. Create a job with a timeout period of three minutes and grace period of one minute.
2. Ping the job URL to activate it
3. Ping that same URL again in less than a minute
4. An email alert should be sent to your mailbox
5. The icon on the dashboard next to the should change to red indicating it is running too often

**Any background context you want to provide?**
1. Previously a user was not able to be sent an E-mail when a job was pinged before the timeout period minus grace period. Now they can.
2. Previously jobs that were run too often would not be shown on the dashboard. Now they can

**What are the relevant pivotal tracker stories?**
[#156577923](https://www.pivotaltracker.com/story/show/156577923)
