### PR TITLE
#157352144 Nag mode checkbox and colours

### DIFF
--- a/hc/api/management/commands/sendalerts.py
+++ b/hc/api/management/commands/sendalerts.py
@@ -46,7 +46,6 @@ class Command(BaseCommand):
         check.status = check.get_status()
         if check.status == "down" and timezone.now() > (check.last_ping + check.timeout + check.grace):
             check.nag_after = timezone.now() + check.nag_interval
-            check.nag_mode = True
         check.save()
 
         tmpl = "\nSending alert, status=%s, code=%s\n"

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -126,6 +126,7 @@ class Check(models.Model):
             "timeout": int(self.timeout.total_seconds()),
             "grace": int(self.grace.total_seconds()),
             "nag_interval": int(self.nag_interval.total_seconds()),
+            "nag_mode": self.nag_mode,
             "n_pings": self.n_pings,
             "status": self.get_status()
         }

--- a/hc/api/tests/test_create_check.py
+++ b/hc/api/tests/test_create_check.py
@@ -33,7 +33,8 @@ class CreateCheckTestCase(BaseTestCase):
             "department": "production",
             "timeout": 3600,
             "grace": 60,
-            "nag_interval": 60
+            "nag_interval": 60,
+            "nag_mode": True
         })
 
         self.assertEqual(r.status_code, 201)
@@ -49,6 +50,7 @@ class CreateCheckTestCase(BaseTestCase):
         self.assertEqual(check.timeout.total_seconds(), 3600)
         self.assertEqual(check.grace.total_seconds(), 60)
         self.assertEqual(check.nag_interval.total_seconds(), 60)
+        self.assertEqual(check.nag_mode, True)
         self.assertEqual(check.n_pings, 0)
         self.assertEqual(check.last_ping, None)
 

--- a/hc/api/views.py
+++ b/hc/api/views.py
@@ -77,6 +77,8 @@ def checks(request):
             check.grace = td(seconds=request.json["grace"])
         if "nag_interval" in request.json:
             check.nag_interval = td(seconds=request.json["nag_interval"])
+        if "nag_mode" in request.json:
+            check.nag_mode = request.json["nag_mode"]
 
         check.save()
 

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -22,6 +22,7 @@ class TimeoutForm(forms.Form):
     timeout = forms.IntegerField(min_value=60, max_value=31104000)
     grace = forms.IntegerField(min_value=60, max_value=31104000)
     nag_interval = forms.IntegerField(min_value=60, max_value=3600)
+    nag_mode = forms.BooleanField(required=False)
 
 
 class AddChannelForm(forms.ModelForm):

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -192,6 +192,7 @@ def update_timeout(request, code):
         check.timeout = td(seconds=form.cleaned_data["timeout"])
         check.grace = td(seconds=form.cleaned_data["grace"])
         check.nag_interval = td(seconds=form.cleaned_data["nag_interval"])
+        check.nag_mode = form.cleaned_data["nag_mode"]
         check.save()
 
     return redirect("hc-checks")

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -58,11 +58,11 @@ body {
 }
 
 .status.icon-up { color: #5cb85c; }
-.status.icon-up.often { color: #d9534f; }
+.status.icon-up.often { color: #af08fc; }
 .status.icon-up.new, .status.icon-paused { color: #CCC; }
 .status.icon-grace { color: #f0ad4e; }
 .status.icon-down { color: #d9534f; }
-.status.icon-nag { color: #d9534f; }
+.status.icon-nag { color: #4ee5f0; }
 
 .hc-dialog {
     background: #FFF;

--- a/static/css/icomoon.css
+++ b/static/css/icomoon.css
@@ -46,7 +46,7 @@
   content: "\e000";
 }
 .icon-nag:before {
-  content: "\e159";
+  content: "\e001";
 }
 .icon-missing:before {
   content: "\e001";

--- a/static/css/my_checks.css
+++ b/static/css/my_checks.css
@@ -32,7 +32,7 @@
 }
 
 #grace-slider {
-    margin: 20px 50px 110px 50px;
+    margin: 20px 50px 80px 50px;
 }
 
 #grace-slider.noUi-connect {
@@ -40,7 +40,7 @@
 }
 
 #nag-slider {
-    margin: 20px 50px 140px 50px;
+    margin: 20px 50px 80px 50px;
 }
 
 #nag-slider.noUi-connect {
@@ -96,3 +96,70 @@
  #show-usage-modal .tab-content {
      margin-top: 15px;
  }
+
+.nag-mode-div {
+    position: relative;
+}
+
+.nag-mode-text {
+    position: absolute;
+    top: -40px;
+    left: 100px;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 53px;
+    height: 28px;
+    margin-left: 30px;
+}
+  
+/* Hide default HTML checkbox */
+.switch input {display:none;}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+input:checked + .slider {
+    background-color: #22bc66;
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px #22bc66;
+}
+
+input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+}
+
+.slider.round {
+    border-radius: 34px;
+}
+
+.slider.round:before {
+    border-radius: 50%;
+}

--- a/static/js/checks.js
+++ b/static/js/checks.js
@@ -141,6 +141,11 @@ $(function () {
         periodSlider.noUiSlider.set($this.data("timeout"))
         graceSlider.noUiSlider.set($this.data("grace"))
         nagSlider.noUiSlider.set($this.data("nag"))
+        if ($this.data("nag-mode") === "True") {
+            $('#update-timeout-nag-mode').prop('checked', true);
+        } else {
+            $('#update-timeout-nag-mode').prop('checked', false);
+        }
         $('#update-timeout-modal').modal({"show":true, "backdrop":"static"});
 
         return false;

--- a/templates/front/my_checks.html
+++ b/templates/front/my_checks.html
@@ -194,6 +194,20 @@
                     </div>
                     <div id="nag-slider"></div>
 
+                    <div class="checkbox update-timeout-info text-left">
+                        <label
+                            class="switch"
+                            data-toggle="tooltip"
+                            title="When the nag mode is selected, the user will be nagged until the check resolved">
+                            <input
+                                id="update-timeout-nag-mode"
+                                name="nag_mode"
+                                type="checkbox">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                    <div class="nag-mode-div"><span class="nag-mode-text">Nag mode</span></div>
+
                     <div class="update-timeout-terms">
                         <p>
                             <span>Period</span>

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -28,7 +28,8 @@
                 <span class="status icon-up often" 
                     data-toggle="tooltip" title="This job is being run too often."></span>
             {% elif check.get_status == "down" and check.nag_mode == True %}
-                <span class="status icon-nag"></span>
+                <span class="status icon-nag"
+                    data-toggle="tooltip" title="Nagging until the check is resolved."></span>
             {% elif check.get_status == "down" %}
                 <span class="status icon-down"></span>
             {% endif %}
@@ -62,6 +63,7 @@
                 data-timeout="{{ check.timeout.total_seconds }}"
                 data-grace="{{ check.grace.total_seconds }}"
                 data-nag="{{ check.nag_interval.total_seconds }}"
+                data-nag-mode="{{ check.nag_mode }}"
                 class="timeout-grace">
                 {{ check.timeout|hc_duration }}
                 <br />

--- a/templates/front/my_checks_mobile.html
+++ b/templates/front/my_checks_mobile.html
@@ -67,6 +67,10 @@
                 <td>{{ check.nag_interval|hc_duration }}</td>
             </tr>
             <tr>
+                <th>Nag Mode</th>
+                <td>{% if check.nag_mode %} On {% else %} Off {% endif %}</td>
+            </tr>
+            <tr>
                 <th>Last Ping</th>
                 <td>
                     {% if check.last_ping %}
@@ -96,6 +100,7 @@
                 data-timeout="{{ check.timeout.total_seconds }}"
                 data-grace="{{ check.grace.total_seconds }}"
                 data-nag="{{ check.nag_interval.total_seconds }}"
+                data-nag-mode="{{ check.nag_mode }}"
                 class="btn btn-default timeout-grace">Change Period</a>
 
             <a href="{% url 'hc-log' check.code %}" class="btn btn-default">Log</a>


### PR DESCRIPTION
#### What does this PR do?
Allow a user to turn the Nag mode on or off.
Change the Nag icon.
Change colours for Nagging and running too often.

#### Description of Task to be completed?
The system will keep nagging the user if they turn on Nag mode.
![image](https://user-images.githubusercontent.com/7848682/39878707-ae844a04-5481-11e8-9c6c-373afe7745f3.png)

Nag icon changed.
Colours for Nagging and running too often also changed.
![image](https://user-images.githubusercontent.com/7848682/39879495-a197f532-5483-11e8-8311-33007d131f16.png)

#### How should this be manually tested?
Create a new check and test the Nag mode switch.
Review the colour choices.

#### Any background context you want to provide?
Prior to this, the user could not decide whether to be nagged or not, and the colour choices were not desired.

#### What are the relevant pivotal tracker stories?
[#157352144](https://www.pivotaltracker.com/story/show/157352144)